### PR TITLE
Reduce dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 gem 'rake', '~> 13.0'
 
 gem 'factory_bot_rails'
-gem 'rails'
 gem 'rspec', '~> 3.0'
 gem 'rspec-rails', '~> 3.0'
 gem 'sqlite3'

--- a/bulletmark_repairer.gemspec
+++ b/bulletmark_repairer.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activerecord'
   spec.add_dependency 'bullet'
   spec.add_dependency 'parser'
-  spec.add_dependency 'rails'
+  spec.add_dependency 'railties'
 end


### PR DESCRIPTION
The rails depends on a lot of gems, like activestorage, actionmailer and so on.
However, this gem depends on only railties and activerecord.

----
Here is a diff of Gemfile.lock between this change.
<details>
<summary>Diff</summary>

``` diff
diff --git a/Gemfile.lock b/Gemfile.lock
index 3f90100..b3a5a9b 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,39 +2,14 @@ PATH
   remote: .
   specs:
     bulletmark_repairer (0.1.1)
+      activerecord
       bullet
       parser
-      rails
+      railties
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.1.0)
-      actionpack (= 7.1.0)
-      activesupport (= 7.1.0)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-      zeitwerk (~> 2.6)
-    actionmailbox (7.1.0)
-      actionpack (= 7.1.0)
-      activejob (= 7.1.0)
-      activerecord (= 7.1.0)
-      activestorage (= 7.1.0)
-      activesupport (= 7.1.0)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.1.0)
-      actionpack (= 7.1.0)
-      actionview (= 7.1.0)
-      activejob (= 7.1.0)
-      activesupport (= 7.1.0)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.2)
     actionpack (7.1.0)
       actionview (= 7.1.0)
       activesupport (= 7.1.0)
@@ -44,34 +19,18 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    actiontext (7.1.0)
-      actionpack (= 7.1.0)
-      activerecord (= 7.1.0)
-      activestorage (= 7.1.0)
-      activesupport (= 7.1.0)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
     actionview (7.1.0)
       activesupport (= 7.1.0)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activejob (7.1.0)
-      activesupport (= 7.1.0)
-      globalid (>= 0.3.6)
     activemodel (7.1.0)
       activesupport (= 7.1.0)
     activerecord (7.1.0)
       activemodel (= 7.1.0)
       activesupport (= 7.1.0)
       timeout (>= 0.4.0)
-    activestorage (7.1.0)
-      actionpack (= 7.1.0)
-      activejob (= 7.1.0)
-      activerecord (= 7.1.0)
-      activesupport (= 7.1.0)
-      marcel (~> 1.0)
     activesupport (7.1.0)
       base64
       bigdecimal
@@ -93,7 +52,6 @@ GEM
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
-    date (3.3.3)
     diff-lcs (1.5.0)
     drb (2.1.1)
       ruby2_keywords
@@ -103,8 +61,6 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    globalid (1.2.1)
-      activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -116,25 +72,8 @@ GEM
     loofah (2.21.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.8.1)
-      mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
-    marcel (1.0.2)
-    mini_mime (1.1.5)
     minitest (5.20.0)
     mutex_m (0.1.2)
-    net-imap (0.4.1)
-      date
-      net-protocol
-    net-pop (0.1.2)
-      net-protocol
-    net-protocol (0.2.1)
-      timeout
-    net-smtp (0.4.0)
-      net-protocol
-    nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -152,20 +91,6 @@ GEM
     rackup (2.1.0)
       rack (>= 3)
       webrick (~> 1.8)
-    rails (7.1.0)
-      actioncable (= 7.1.0)
-      actionmailbox (= 7.1.0)
-      actionmailer (= 7.1.0)
-      actionpack (= 7.1.0)
-      actiontext (= 7.1.0)
-      actionview (= 7.1.0)
-      activejob (= 7.1.0)
-      activemodel (= 7.1.0)
-      activerecord (= 7.1.0)
-      activestorage (= 7.1.0)
-      activesupport (= 7.1.0)
-      bundler (>= 1.15.0)
-      railties (= 7.1.0)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -235,9 +160,6 @@ GEM
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
     webrick (1.8.1)
-    websocket-driver (0.7.6)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -247,7 +169,6 @@ DEPENDENCIES
   bulletmark_repairer!
   byebug
   factory_bot_rails
-  rails
   rake (~> 13.0)
   rspec (~> 3.0)
   rspec-rails (~> 3.0)
```

</details>