### PR TITLE
Ignore test db directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@
 Gemfile.lock
 .byebug_history
 spec/log
+spec/fake_app/db/
 spec/fake_app/tmp


### PR DESCRIPTION
When run tests, `spec/fake_app/db/test.sqlite3*` will be generated.