### PR TITLE
Add spell checking GitHub Actions workflow

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,15 @@
+name: CodeSpell
+on:
+  - pull_request
+jobs:
+  codespell:
+    name: CodeSpell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: CodeSpell
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          check_hidden: true
+          ignore_words_file: .codespellignore

--- a/lib/bulletmark_repairer/configuration.rb
+++ b/lib/bulletmark_repairer/configuration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BulletmarkRepairer
-  class Configration
+  class Configuration
     attr_accessor :skip_file_list, :logger
     attr_writer :debug
 
@@ -22,7 +22,7 @@ module BulletmarkRepairer
     end
 
     def config
-      @config ||= Configration.new
+      @config ||= Configuration.new
     end
   end
 end


### PR DESCRIPTION
This PR adds spell checking GitHub Actions workflow and fixes typos.

How about the following spell check by CI?
- https://github.com/codespell-project/codespell

The run detected the following spelling errors:
https://github.com/makicamel/bulletmark_repairer/actions/runs/6544033636/job/17769686578?pr=5
```
Resulting CLI options  --check-filenames --check-hidden --skip ./.git --ignore-words .codespellignore
2
Error: ./lib/bulletmark_repairer/configuration.rb:4: Configration ==> Configuration
Error: ./lib/bulletmark_repairer/configuration.rb:25: Configration ==> Configuration
```