### PR TITLE
Fix a redundant auto-correct for multiple tests with n+1 queries when running RSpec

### DIFF
--- a/lib/bulletmark_repairer/controller_corrector.rb
+++ b/lib/bulletmark_repairer/controller_corrector.rb
@@ -46,10 +46,12 @@ class ControllerCorrector < Parser::TreeRewriter
     return unless node.respond_to?(:to_sexp_array)
 
     type, identifier = node.to_sexp_array.take(2)
-
     if type == :ivasgn && identifier == instance_variable_name
-      insert_after node.children.last.location.expression, ".includes(#{associations})"
-      @patched = true
+      inserted = ".includes(#{associations})"
+      unless node.location.expression.source.include?(inserted)
+        insert_after node.children.last.location.expression, inserted
+        @patched = true
+      end
     else
       node
         .children

--- a/lib/bulletmark_repairer/corrector.rb
+++ b/lib/bulletmark_repairer/corrector.rb
@@ -26,8 +26,11 @@ class Corrector < Parser::TreeRewriter
 
     # TODO: Patch Enumerable methods other than each and map
     if node.children.last.in?(%i[each map])
-      insert_after node.children[0].location.expression, ".includes(#{associations})"
-      @patched = true
+      inserted = ".includes(#{associations})"
+      unless node.location.expression.source.include?(inserted)
+        insert_after node.children[0].location.expression, ".includes(#{associations})"
+        @patched = true
+      end
     else
       node.children.each { |child_node| insert_includes(node: child_node) }
     end
@@ -39,8 +42,11 @@ class Corrector < Parser::TreeRewriter
     return unless node.location.expression.line <= line_no && line_no <= node.location.expression.last_line
 
     if node.type == type
-      insert_after node.children.last.location.expression, ".includes(#{associations})"
-      @patched = true
+      inserted = ".includes(#{associations})"
+      unless node.location.expression.source.include?(inserted)
+        insert_after node.children.last.location.expression, ".includes(#{associations})"
+        @patched = true
+      end
     else
       node.children.each { |child_node| insert_includes_for_vasgn(node: child_node, type: type) }
     end


### PR DESCRIPTION
This PR fix a redundant auto-correct for multiple tests with n+1 queries when running RSpec.
For example, suppose there are three tests for the same query that require the following modifications:

```diff
- @plays = @plays.joins(:actors)
+ @plays = @plays.joins(:actors).includes([:actors])
```

However, in practice, `.includes` is added as many times as the number of `examples` for which n + 1 queries are issued, for example

```diff
- @plays = @plays.joins(:actors)
+ @plays = @plays.joins(:actors).includes([:actors]).includes([:actors]).includes([:actors])
```
