### PR TITLE
Refactor GitHub Actions workflow triggers for clarity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Ruby
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Currently, creating a PR triggers the same test to run twice, which is redundant. Therefore, we modified it to specify the branch to eliminate redundancy.